### PR TITLE
fix: add missing providers to App test state

### DIFF
--- a/packages/frontend/src/App.test.tsx
+++ b/packages/frontend/src/App.test.tsx
@@ -13,6 +13,16 @@ describe("App", () => {
       showHistory: false,
       prompt: "",
       generatedCode: "// OpenSCAD code will appear here",
+      availableProviders: [
+        {
+          id: "gemini",
+          name: "Gemini",
+          models: ["gemini-2.5-flash"],
+          configured: true,
+        },
+      ],
+      provider: "gemini",
+      selectedModel: "gemini-2.5-flash",
     });
   });
 


### PR DESCRIPTION
## Summary
- Fix failing test in `App.test.tsx` by adding `availableProviders`, `provider`, and `selectedModel` to the test's beforeEach state.

## Root Cause
The test was missing the `availableProviders` in the store state. When ChatPanel rendered, it saw no configured providers and returned early with an error message instead of calling the API to generate code.

## Testing
- All 85 tests now pass