### PR TITLE
fix: handle empty jq results in workflow gate checks

### DIFF
--- a/.github/workflows/opencode-autofix.yml
+++ b/.github/workflows/opencode-autofix.yml
@@ -14,7 +14,7 @@ jobs:
       - name: Check for ready-to-start issues
         id: count
         run: |
-          count=$(gh issue list --state open --label "ready-to-start" --json number 2>/dev/null | jq '. | length')
+          count=$(gh issue list --state open --label "ready-to-start" --json number 2>/dev/null | jq 'length // 0')
           echo "Ready-to-start issues: $count"
           if [ "$count" -gt 0 ]; then
             echo "has_ready=true" >> $GITHUB_OUTPUT

--- a/.github/workflows/opencode-triage.yml
+++ b/.github/workflows/opencode-triage.yml
@@ -20,8 +20,8 @@ jobs:
         id: count
         run: |
           # Count open issues WITHOUT ready-to-start label
-          total=$(gh issue list --state open --json number 2>/dev/null | jq '. | length')
-          ready=$(gh issue list --state open --label "ready-to-start" --json number 2>/dev/null | jq '. | length')
+          total=$(gh issue list --state open --json number 2>/dev/null | jq 'length // 0')
+          ready=$(gh issue list --state open --label "ready-to-start" --json number 2>/dev/null | jq 'length // 0')
 
           # If no ready-to-start, all need triage. Otherwise, check remaining.
           if [ "$ready" -eq 0 ]; then


### PR DESCRIPTION
## Summary
- Fixed `jq` returning empty when no issues match, causing integer expression error in triage and autofix workflows
- Changed `jq '. | length'` to `jq 'length // 0'` to provide default value of 0 when results are empty