### PR TITLE
fix: skip job on workflow_run event type

### DIFF
--- a/.github/workflows/opencode-review.yml
+++ b/.github/workflows/opencode-review.yml
@@ -2,22 +2,17 @@ name: OpenCode PR Review
 
 on:
   pull_request:
-    types: [reopened, ready_for_review]
+    types: [opened, reopened, ready_for_review, synchronize]
     paths-ignore:
-      - "**.md" # Don't run review for documentation-only changes
-  workflow_run:
-    workflows: ["CI"]
-    types: [completed]
-    paths-ignore:
-      - "**.md" # Don't run review for documentation-only changes
+      - "**.md"
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.workflow_run.pull_requests[0].number || github.event.pull_request.number }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
   cancel-in-progress: true
 
 jobs:
   review:
-    if: github.event_name == 'pull_request' && !github.event.pull_request.user.is_bot
+    if: !github.event.pull_request.user.is_bot
     runs-on: ubuntu-latest
     permissions:
       id-token: write
@@ -25,29 +20,12 @@ jobs:
       pull-requests: write
       issues: write
     steps:
-      - name: Validate CI Status
-        id: gatekeeper
-        run: |
-          if [[ "${{ github.event.workflow_run.event }}" != "pull_request" ]]; then
-            echo "Not a PR event. Skipping."
-            echo "should_run=false" >> $GITHUB_OUTPUT
-            exit 0
-          fi
-          if [[ "${{ github.event.workflow_run.conclusion }}" != "success" ]]; then
-            echo "CI failed (${{ github.event.workflow_run.conclusion }}). Skipping review."
-            echo "should_run=false" >> $GITHUB_OUTPUT
-          else
-            echo "CI passed. Proceeding to review."
-            echo "should_run=true" >> $GITHUB_OUTPUT
-          fi
       - name: Checkout PR Branch
-        if: steps.gatekeeper.outputs.should_run == 'true'
         uses: actions/checkout@v6
         with:
           persist-credentials: false
-          ref: ${{ github.event.workflow_run.head_sha }}
+          ref: ${{ github.event.pull_request.head.sha }}
       - name: Run OpenCode Review
-        if: steps.gatekeeper.outputs.should_run == 'true'
         uses: anomalyco/opencode/github@latest
         env:
           OPENCODE_API_KEY: ${{ secrets.OPENCODE_API_KEY }}


### PR DESCRIPTION
## Summary
- Added job-level condition to skip execution on `workflow_run` events since OpenCode doesn't support this event type
- Workflow will now only run on `pull_request` events