### PR TITLE
fix: use startsWith to filter bot PRs in review workflow

### DIFF
--- a/.github/workflows/opencode-review.yml
+++ b/.github/workflows/opencode-review.yml
@@ -12,7 +12,7 @@ concurrency:
 
 jobs:
   review:
-    if: "!startsWith(github.event.pull_request.user.login, 'app/')"
+    if: "!github.actor_is_bot"
     runs-on: ubuntu-latest
     permissions:
       id-token: write


### PR DESCRIPTION
## Summary
- Fixed bot PR filter using `github.actor_is_bot` boolean property