### PR TITLE
fix: add checkout step before gh commands in workflows

### DIFF
--- a/.github/workflows/opencode-autofix.yml
+++ b/.github/workflows/opencode-autofix.yml
@@ -11,6 +11,9 @@ jobs:
     outputs:
       has_ready_issues: ${{ steps.count.outputs.has_ready }}
     steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
       - name: Check for ready-to-start issues
         id: count
         env:

--- a/.github/workflows/opencode-triage.yml
+++ b/.github/workflows/opencode-triage.yml
@@ -16,6 +16,9 @@ jobs:
     outputs:
       needs_triage: ${{ steps.count.outputs.needs_triage }}
     steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
       - name: Count issues needing triage
         id: count
         env:


### PR DESCRIPTION
## Summary
- Added `actions/checkout@v6` step before gh commands in triage and autofix gate check jobs
- This fixes the "fatal: not a git repository" error that was causing gh to fail